### PR TITLE
Early loading to beat AppleIntelLpssI2C and prevent SBUS conflicts

### DIFF
--- a/VoodooSMBus/Info.plist
+++ b/VoodooSMBus/Info.plist
@@ -497,5 +497,7 @@
 		<key>com.apple.kpi.mach</key>
 		<string>18.5</string>
 	</dict>
+	<key>OSBundleRequired</key>
+	<string>Root</string>
 </dict>
 </plist>


### PR DESCRIPTION
credit @stevezhengshiqi

Should no longer be necessary to patch `AppleIntelLpssI2C`.