### PR TITLE
Fix timeout, bump version to 3.0

### DIFF
--- a/VoodooSMBus/Info.plist
+++ b/VoodooSMBus/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.2</string>
+	<string>3.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.2</string>
+	<string>3.0</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>VoodooSMBusControllerDriver</key>
@@ -59,7 +59,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2019 leo-labs. All rights reserved.</string>
 	<key>OSBundleCompatibleVersion</key>
-	<string>2.1</string>
+	<string>3.0</string>
 	<key>OSBundleLibraries</key>
 	<dict>
 		<key>com.apple.iokit.IOHIDFamily</key>

--- a/VoodooSMBus/VoodooSMBusControllerDriver.cpp
+++ b/VoodooSMBus/VoodooSMBusControllerDriver.cpp
@@ -16,6 +16,7 @@
 OSDefineMetaClassAndStructors(VoodooSMBusControllerDriver, IOService)
 
 #define super IOService
+#define MILLI_TO_NANO 1000000
 
 bool VoodooSMBusControllerDriver::init(OSDictionary *dict) {
     bool result = super::init(dict);
@@ -81,7 +82,7 @@ bool VoodooSMBusControllerDriver::start(IOService *provider) {
     adapter->features |= FEATURE_BLOCK_BUFFER;
     adapter->features |= FEATURE_HOST_NOTIFY;
     adapter->retries = 3;
-    adapter->timeout = 200000000;
+    adapter->timeout = 200 * MILLI_TO_NANO;
     
     work_loop = reinterpret_cast<IOWorkLoop*>(getWorkLoop());
     if (!work_loop) {


### PR DESCRIPTION
Changes commandSleep from [2 arg version with no timeout](https://developer.apple.com/documentation/kernel/iocommandgate/1811498-commandsleep?language=objc) to [3 arg version with timeout](https://developer.apple.com/documentation/kernel/iocommandgate/1811482-commandsleep?language=objc), and makes it a time deadline as described in docs. Also corrects the last arg from being a timeout to whether or not it's interruptible.

This hopefully fixes issues with Ivy Bridge devices freezing and not giving any sort of log. I tested this implementation of commandSleep with my [PS2 implementation](https://github.com/VoodooSMBus/VoodooRMI/blob/master/VoodooRMI/Functions/F03.cpp#L492) and it waits the proper amount of time before timing out if there isn't any response. I haven't been able to test a system where the SMBus chip doesn't respond though yet.