### PR TITLE
Class match rather than PCI id

### DIFF
--- a/VoodooSMBus/Info.plist
+++ b/VoodooSMBus/Info.plist
@@ -22,12 +22,12 @@
 	<dict>
 		<key>VoodooSMBusControllerDriver</key>
 		<dict>
+			<key>IOPCIClassMatch</key>
+			<string>0c050000&amp;0xffffff00</string>
 			<key>IOProbeScore</key>
 			<integer>400</integer>
 			<key>IOPCIMatchComment</key>
-			<string>Intel SMBus Controller i80 (9d23: Sunrise Point-LP (PCH), a323: Cannon Lake-H (PCH))</string>
-			<key>IOPCIMatch</key>
-			<string>0x9d238086 0xa3238086</string>
+			<string>Intel SMBus Controller i801 (Class 0x0C05)</string>
 			<key>IOProviderClass</key>
 			<string>IOPCIDevice</string>
 			<key>IOClass</key>


### PR DESCRIPTION
Not exactly sure if this is wanted - but this should allow probing/attaching to any SMBus chip without manually specifying every pci id.
This will also try to attach to AMD SMBus controllers as well, but AMD laptop hacks really aren't a thing so I don't think it's a big deal.
I checked the class code and it's consistent even on my old Core 2 Duo machine from ~2007, so it seems pretty foolproof other than attaching to AMD controllers as well.