### PR TITLE
Add new lines to every message as well as VSMB for easy dmesg logging

### DIFF
--- a/VoodooSMBus/VoodooSMBusDeviceNub.cpp
+++ b/VoodooSMBus/VoodooSMBusDeviceNub.cpp
@@ -37,7 +37,7 @@ void VoodooSMBusDeviceNub::handleHostNotify() {
     kern_return_t ret = kernel_thread_start(OSMemberFunctionCast(thread_continue_t, this, &VoodooSMBusDeviceNub::handleHostNotifyThreaded), this, &new_thread);
 
     if (ret != KERN_SUCCESS) {
-        IOLogDebug(" Thread error while attemping to handle host notify in device nub.\n");
+        IOLogDebug(" Thread error while attemping to handle host notify in device nub.");
     } else {
         thread_deallocate(new_thread);
     }
@@ -50,7 +50,7 @@ bool VoodooSMBusDeviceNub::attach(IOService* provider, UInt8 address) {
     
     controller = OSDynamicCast(VoodooSMBusControllerDriver, provider);
     if (!controller) {
-        IOLog("%s Could not get controller\n", provider->getName());
+        IOLogError("%s Could not get controller", provider->getName());
         return false;
     }
     

--- a/VoodooSMBus/helpers.hpp
+++ b/VoodooSMBus/helpers.hpp
@@ -11,8 +11,13 @@ typedef UInt16 __u16;
 typedef __u16 u16;
 typedef SInt32 s32;
 
+#define IOLogInfo(format, ...) IOLog("VSMB - Info: " format "\n", ## __VA_ARGS__)
 #define IOLogError(format, ...) IOLog("VSMB - Error: " format "\n", ## __VA_ARGS__)
+#ifdef DEBUG
 #define IOLogDebug(format, ...) IOLog("VSMB - Debug: " format "\n", ## __VA_ARGS__)
+#elif
+#define IOLogDebug(format, ...)
+#endif
 
 void addrToDictKey(u8 address, char* key);
 const char* getMatchedName(IOService* provider);

--- a/VoodooSMBus/helpers.hpp
+++ b/VoodooSMBus/helpers.hpp
@@ -11,8 +11,8 @@ typedef UInt16 __u16;
 typedef __u16 u16;
 typedef SInt32 s32;
 
-#define IOLogError(arg...) IOLog("Error: " arg)
-#define IOLogDebug(arg...) IOLog("Debug: " arg)
+#define IOLogError(format, ...) IOLog("VSMB - Error: " format "\n", ## __VA_ARGS__)
+#define IOLogDebug(format, ...) IOLog("VSMB - Debug: " format "\n", ## __VA_ARGS__)
 
 void addrToDictKey(u8 address, char* key);
 const char* getMatchedName(IOService* provider);


### PR DESCRIPTION
Replicates what I did [here](https://github.com/VoodooSMBus/VoodooRMI/blob/master/VoodooRMI/Utility/Logging.h). `dmesg` is useful when trying to get logs from early boot, as the `log` command tends to work really terribly. I'm not exactly what should be an error vs info or debug log - so I'm mostly leaving it as is.

Closes #56 